### PR TITLE
Allow GET/POST methods on endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanohttp"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a087b38dfd5b94eced1e3974b4d58775ada79acd5f924f60c0373b03a24b1ace"
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +386,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "nanohttp",
  "serde",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ multithreaded = []
 [dependencies]
 anyhow = "1.0.79"
 clap = {version = "4.4.16", features = ["derive"]}
+nanohttp = "0.2.0"
 serde = {version = "1.0", features = ["derive"]}
 tokio = {version = "1.35.1", features = ["full"]}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,19 @@ pub enum ResponseFormat {
     Html,
 }
 
+impl ToString for ResponseFormat {
+    fn to_string(&self) -> String {
+        match *self {
+            ResponseFormat::Json => {
+                "application/json".to_string()
+            },
+            ResponseFormat::Html => {
+                "text/html".to_string()
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum ResponseFormatError {
     ParseFailedError(String),
@@ -70,25 +83,12 @@ pub struct Response {
 impl ToString for Response {
     /// Turns response into http response string
     fn to_string(&self) -> String {
-        let mut response = String::from("HTTP/1.1 200 OK\r\n");
-        match &self.format {
-            &ResponseFormat::Html => {
-                response.push_str("Content-Type: text/html; charset=utf-8\r\n");
-            }
-            &ResponseFormat::Json => {
-                response.push_str("Content-Type: application/json\r\n");
-            }
+        match &self.content {
+            Some(content) => {
+                content.to_string()
+            },
+            None => "".to_string()
         }
-        let content = match &self.content {
-            Some(content) => content,
-            None => "",
-        };
-        response.push_str("Content-Length: ");
-        response.push_str(&content.len().to_string());
-        response.push_str("\r\n\r\n");
-        response.push_str(&content);
-
-        response
     }
 }
 #[derive(Debug, PartialEq, Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,12 +23,8 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let map = populate_map(&args);
     let host = match &args.allow_remote {
-        true => {
-            "0.0.0.0"
-        },
-        false => {
-            "127.0.0.1"
-        }
+        true => "0.0.0.0",
+        false => "127.0.0.1",
     };
 
     let map_ref = Arc::from(map.clone());
@@ -65,12 +61,8 @@ fn main() -> Result<()> {
     let map = populate_map(&args);
 
     let host = match &args.allow_remote {
-        true => {
-            "0.0.0.0"
-        },
-        false => {
-            "127.0.0.1"
-        }
+        true => "0.0.0.0",
+        false => "127.0.0.1",
     };
     let end_point: String = host.to_owned() + ":" + &port.to_string();
     let listener = std::net::TcpListener::bind(&end_point)?;

--- a/src/singlethreaded.rs
+++ b/src/singlethreaded.rs
@@ -1,18 +1,57 @@
+use std::io::Read;
 use std::{collections::HashMap, net::TcpStream};
 
+use core::str::from_utf8;
 use crate::Response;
+use nanohttp::{Method, Request as HttpRequest, Response as HttpResponse, Status};
 
-use std::io::{BufRead, BufReader, BufWriter, Result, Write};
+use std::io::{BufWriter, Result, Write};
 pub struct SingleBufTcpStream {
     pub input: BufWriter<TcpStream>,
-    pub output: BufReader<TcpStream>,
+    pub output: TcpStream,
 }
 
 impl SingleBufTcpStream {
     pub fn new(stream: &TcpStream) -> Result<Self> {
         let input = BufWriter::new(stream.try_clone()?);
-        let output = BufReader::new(stream.try_clone()?);
+        let output = stream.try_clone()?;
         Ok(SingleBufTcpStream { input, output })
+    }
+}
+
+fn handle(req: HttpRequest, map: &HashMap<String, Response>) -> HttpResponse {
+    let method = req.method;
+    match method {
+        Method::GET => {
+            if let Some(data) = map.get(req.path.uri.as_str()) {
+                let format = data.format.to_string();
+                match &data.content {
+                    Some(data) => {
+                        println!("GET {}, response: {:?}", &req.path.uri.as_str(), data);
+                        HttpResponse::content(&data, &format).status(Status::Ok)
+                    },
+                    None => {
+                        println!("GET {} response empty", &req.path.uri.as_str());
+                        HttpResponse::empty().status(Status::Ok)
+                    }
+                }
+            } else {
+                println!("GET {} 404", &req.path.uri.as_str());
+                HttpResponse::empty().status(Status::NotFound)
+            }
+        }
+
+        Method::POST => {
+            if let Some(data) = map.get(req.path.uri.as_str()) {
+                let format = data.format.to_string();
+                println!("Post {}, response: {:?}", &req.path.uri.as_str(), &req.body);
+                HttpResponse::content(&req.body, &format).status(Status::Ok) 
+            } else {
+                println!("Post {}, 404", &req.path.uri.as_str());
+                HttpResponse::empty().status(Status::NotFound)
+            }
+        }
+        _ => HttpResponse::empty().status(Status::NotAllowed)
     }
 }
 
@@ -20,38 +59,14 @@ pub fn handle_connection(
     mut streams: SingleBufTcpStream,
     map: &HashMap<String, Response>,
 ) -> Result<()> {
-    let buf_reader = BufReader::new(&mut streams.output);
-    let http_request: Vec<_> = buf_reader
-        .lines()
-        .map(|result| result.unwrap())
-        .take_while(|line| !line.is_empty())
-        .collect();
+    let mut buffer = [0; 1024];
+    streams.output.read(&mut buffer)?;
+    let req_text = from_utf8(&buffer).unwrap().trim_end_matches("\0");
+    let req = HttpRequest::from_string(&req_text).unwrap();
+    let res = handle(req, map).to_string();
+    let bytes = res.as_bytes();
 
-    let string_line = match http_request.first() {
-        Some(line) => line,
-        None => "",
-    };
-
-    let path = string_line
-        .trim_start_matches("GET ")
-        .trim_start_matches("POST ")
-        .trim_end_matches(" HTTP/1.1");
-
-    if map.get(path).is_some() {
-        if let Some(matched_path) = map.get(path) {
-            streams.input.write(matched_path.to_string().as_bytes())?;
-            println!(
-                "Matched path: {}, responded with: {:?}",
-                path,
-                matched_path.to_string()
-            );
-        }
-    } else {
-        streams
-            .input
-            .write("HTTP/1.0 404 Not Found\r\n\r\nNot found".as_bytes())?;
-        println!("Unmatched path: {}", path);
-    }
+    streams.input.write(bytes)?;
     streams.input.flush()?;
     Ok(())
 }


### PR DESCRIPTION
Use crate nanohttp for prettier request parsing
allow GET/POST methods on endpoints, GET works as usual, POST returns the data that was posted